### PR TITLE
refactor(repository): Remove custom find method to fix beanie error

### DIFF
--- a/app/common/repository/base.py
+++ b/app/common/repository/base.py
@@ -16,13 +16,6 @@ class MongoBaseRepository(Generic[BeanieDocument]):
     def __init__(self, collection: Type[BeanieDocument]):
         self.collection = collection
 
-    async def find(self, *args, **kwargs) -> list[BeanieDocument]:
-        """
-        Find documents in the collection.
-        """
-        return await self.collection.find(*args, **kwargs).to_list(length=None)
-    
-
     async def find_pipeline(self, pipeline: list[dict[str, Any]]) -> list[BeanieDocument]:
         """
         Find documents using an aggregation pipeline.

--- a/app/repository/mongo.py
+++ b/app/repository/mongo.py
@@ -24,7 +24,7 @@ class KeyframeRepository(MongoBaseRepository[Keyframe]):
     async def get_keyframe_by_list_of_keys(
         self, keys: list[int]
     ):
-        result = await self.find({"key": {"$in": keys}})
+        result = await self.collection.find({"key": {"$in": keys}}).to_list(length=None)
         return [
             KeyframeInterface(
                 key=keyframe.key,
@@ -43,12 +43,12 @@ class KeyframeRepository(MongoBaseRepository[Keyframe]):
         group_num = pivot_frame.group_num
 
         # Truy vấn tất cả keyframes cùng video_num và group_num (AND)
-        result = await self.find({
+        result = await self.collection.find({
             "$and": [
                 {"video_num": video_num},
                 {"group_num": group_num}
             ]
-        })
+        }).to_list(length=None)
 
         return [
             KeyframeInterface(
@@ -64,7 +64,7 @@ class KeyframeRepository(MongoBaseRepository[Keyframe]):
         self, 
         keyframe_num: int,
     ):
-        result = await self.find({"keyframe_num": keyframe_num})
+        result = await self.collection.find({"keyframe_num": keyframe_num}).to_list(length=None)
         return [
             KeyframeInterface(
                 key=keyframe.key,


### PR DESCRIPTION
The custom `find` method in `MongoBaseRepository` was incorrectly shadowing the `beanie.Document.find` class method. This caused a `TypeError` deep within the `beanie` library when performing find operations.

This commit removes the custom `find` method and updates the `KeyframeRepository` to use the `motor` collection's `find` method directly (`self.collection.find`). This resolves the error and simplifies the repository implementation by using the library's intended patterns.